### PR TITLE
STEP 18: Kafka Outbox Pattern / 발행 실패 재처리 구현 및 테스트 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
     testImplementation 'com.h2database:h2'
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka:3.0.10'
+    // Kafka Test 및 EmbeddedKafka 의존성
+    testImplementation 'org.springframework.kafka:spring-kafka-test:3.0.10'
+    // Testcontainers - Kafka
+    testImplementation 'org.testcontainers:kafka:1.19.0'
 }
 
 test {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/src/main/java/com/consertreservation/application/scheduler/OutboxScheduler.java
+++ b/src/main/java/com/consertreservation/application/scheduler/OutboxScheduler.java
@@ -1,0 +1,49 @@
+package com.consertreservation.application.scheduler;
+
+import com.consertreservation.domain.model.OutboxEvent;
+import com.consertreservation.domain.repository.OutboxRepository;
+import com.consertreservation.kafka.KafkaOutboxPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class OutboxScheduler {
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaOutboxPublisher kafkaOutboxPublisher;
+
+    public OutboxScheduler(OutboxRepository outboxRepository, KafkaOutboxPublisher kafkaOutboxPublisher) {
+        this.outboxRepository = outboxRepository;
+        this.kafkaOutboxPublisher = kafkaOutboxPublisher;
+    }
+
+    @Scheduled(fixedRate = 5000) // 5초마다 실행
+    public void processPendingEvents() {
+        // PENDING 상태 처리
+        List<OutboxEvent> pendingEvents = outboxRepository.findByStatus("PENDING");
+        handleEvents(pendingEvents);
+    }
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    public void retryFailedEvents() {
+        // FAILED 상태 재처리
+        List<OutboxEvent> failedEvents = outboxRepository.findByStatus("FAILED");
+        handleEvents(failedEvents);
+    }
+
+    private void handleEvents(List<OutboxEvent> events) {
+        for (OutboxEvent event : events) {
+            try {
+                kafkaOutboxPublisher.publish(event);
+                event.setStatus("PROCESSED");
+            } catch (Exception e) {
+                event.setStatus("FAILED");
+                System.err.println("Kafka 발행 실패: " + e.getMessage());
+            }
+            outboxRepository.save(event);
+        }
+    }
+}
+

--- a/src/main/java/com/consertreservation/application/service/usecase/reservation/ReserveSeatUseCase.java
+++ b/src/main/java/com/consertreservation/application/service/usecase/reservation/ReserveSeatUseCase.java
@@ -1,9 +1,12 @@
 package com.consertreservation.application.service.usecase.reservation;
 
+import com.consertreservation.domain.model.OutboxEvent;
 import com.consertreservation.domain.model.Seat;
 import com.consertreservation.domain.model.Waitlist;
+import com.consertreservation.domain.repository.OutboxRepository;
 import com.consertreservation.domain.repository.SeatRepository;
 import com.consertreservation.domain.repository.WaitlistRepository;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,10 +19,12 @@ public class ReserveSeatUseCase {
 
     private final SeatRepository seatRepository;
     private final WaitlistRepository waitlistRepository;
+    private final OutboxRepository outboxRepository;
 
-    public ReserveSeatUseCase(SeatRepository seatRepository, WaitlistRepository waitlistRepository) {
+    public ReserveSeatUseCase(SeatRepository seatRepository, WaitlistRepository waitlistRepository, KafkaTemplate<String, String> kafkaTemplate, OutboxRepository outboxRepository) {
         this.seatRepository = seatRepository;
         this.waitlistRepository = waitlistRepository;
+        this.outboxRepository = outboxRepository;
     }
     @Transactional
     public void execute(Long concertId, String seatNumber, String reservedBy) {
@@ -28,9 +33,23 @@ public class ReserveSeatUseCase {
         // 기 예약 체크(상태가 AVAILABLE인지 확인)
         if (seat.getSeatStatus() != Seat.SeatStatus.AVAILABLE) {
             addToWaitlist(concertId, seatNumber, reservedBy); // 대기열에 추가
+            // Outbox에 대기열 추가 이벤트 저장
+            saveToOutbox(
+                    "Waitlist",
+                    seatNumber,
+                    "WAITLIST_ADDED",
+                    String.format("{\"userId\": \"%s\", \"concertId\": \"%d\", \"seatNumber\": \"%s\"}", reservedBy, concertId, seatNumber)
+            );
             return;
         }
         reserveSeat(seat, reservedBy); // 변경 사항 저장
+        // Outbox에 예약 성공 이벤트 저장
+        saveToOutbox(
+                "Reservation",
+                seatNumber,
+                "SEAT_RESERVED",
+                String.format("{\"userId\": \"%s\", \"concertId\": \"%d\", \"seatNumber\": \"%s\"}", reservedBy, concertId, seatNumber)
+        );
     }
 
     Seat findSeat(Long concertId, String seatNumber) {
@@ -46,7 +65,6 @@ public class ReserveSeatUseCase {
         waitlist.setReservationAttemptTime(LocalDateTime.now());
 
         waitlistRepository.save(waitlist);
-        throw new IllegalStateException("Seat is not available, added to waitlist");
     }
 
     void reserveSeat(Seat seat, String reservedBy) {
@@ -56,4 +74,14 @@ public class ReserveSeatUseCase {
         seatRepository.save(seat);
     }
 
+    private void saveToOutbox(String aggregateType, String aggregateId, String eventType, String payload) {
+        OutboxEvent event = new OutboxEvent();
+        event.setAggregateType(aggregateType); // 예: "Reservation"
+        event.setAggregateId(aggregateId);     // 예: 좌석 ID
+        event.setEventType(eventType);         // 예: "SEAT_RESERVED"
+        event.setPayload(payload);             // 예: 예약 상세 정보(JSON)
+        event.setStatus("PENDING");            // 초기 상태
+        event.setCreatedAt(LocalDateTime.now());
+        outboxRepository.save(event);
+    }
 }

--- a/src/main/java/com/consertreservation/domain/model/OutboxEvent.java
+++ b/src/main/java/com/consertreservation/domain/model/OutboxEvent.java
@@ -1,0 +1,89 @@
+package com.consertreservation.domain.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_events")
+public class OutboxEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String topic; // 메시지가 발행될 Kafka 토픽 이름
+    private String aggregateType;
+    private String aggregateId;
+    private String eventType;
+
+    @Lob
+    private String payload;
+
+    private String status = "PENDING";
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    // Getters and Setters
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public void setEventType(String eventType) {
+        this.eventType = eventType;
+    }
+
+    public String getAggregateId() {
+        return aggregateId;
+    }
+
+    public void setAggregateId(String aggregateId) {
+        this.aggregateId = aggregateId;
+    }
+
+    public String getAggregateType() {
+        return aggregateType;
+    }
+
+    public void setAggregateType(String aggregateType) {
+        this.aggregateType = aggregateType;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/consertreservation/domain/repository/OutboxRepository.java
+++ b/src/main/java/com/consertreservation/domain/repository/OutboxRepository.java
@@ -1,0 +1,9 @@
+package com.consertreservation.domain.repository;
+
+import com.consertreservation.domain.model.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface OutboxRepository extends JpaRepository<OutboxEvent, Long> {
+    List<OutboxEvent> findByStatus(String status); // PENDING 상태 조회
+}

--- a/src/main/java/com/consertreservation/kafka/KafkaOutboxPublisher.java
+++ b/src/main/java/com/consertreservation/kafka/KafkaOutboxPublisher.java
@@ -1,0 +1,26 @@
+package com.consertreservation.kafka;
+
+import com.consertreservation.domain.model.OutboxEvent;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaOutboxPublisher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public KafkaOutboxPublisher(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void publish(OutboxEvent event) {
+        try {
+            // Kafka로 메시지 발행
+            kafkaTemplate.send(event.getAggregateType(), event.getPayload());
+            System.out.println("Kafka로 이벤트 발행 성공: " + event);
+        } catch (Exception e) {
+            System.err.println("Kafka 발행 실패: " + e.getMessage());
+            throw e; // 실패 시 예외를 다시 던져 처리
+        }
+    }
+}

--- a/src/main/java/com/consertreservation/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/com/consertreservation/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,30 @@
+package com.consertreservation.kafka.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/consertreservation/kafka/consumer/KafkaConsumerService.java
+++ b/src/main/java/com/consertreservation/kafka/consumer/KafkaConsumerService.java
@@ -1,0 +1,13 @@
+package com.consertreservation.kafka.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaConsumerService {
+
+    @KafkaListener(topics = "${spring.kafka.topic.concert-events}", groupId = "${spring.kafka.consumer.group-id}")
+    public void consumeMessage(String message) {
+        System.out.println("Consumed message: " + message);
+    }
+}

--- a/src/main/java/com/consertreservation/kafka/controller/KafkaController.java
+++ b/src/main/java/com/consertreservation/kafka/controller/KafkaController.java
@@ -1,0 +1,22 @@
+package com.consertreservation.kafka.controller;
+
+import com.consertreservation.kafka.producer.KafkaProducerService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class KafkaController {
+
+    private final KafkaProducerService producerService;
+
+    public KafkaController(KafkaProducerService producerService) {
+        this.producerService = producerService;
+    }
+
+    @GetMapping("/api/kafka/publish")
+    public String publishMessage(@RequestParam String message) {
+        producerService.sendMessage(message);
+        return "Message sent to Kafka topic!";
+    }
+}

--- a/src/main/java/com/consertreservation/kafka/producer/KafkaProducerService.java
+++ b/src/main/java/com/consertreservation/kafka/producer/KafkaProducerService.java
@@ -1,0 +1,23 @@
+package com.consertreservation.kafka.producer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${spring.kafka.topic.concert-events}")
+    private String topic;
+
+    public KafkaProducerService(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(String message) {
+        kafkaTemplate.send(topic, message);
+        System.out.println("Produced message: " + message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,26 +1,42 @@
 # Spring ?????? ??
 spring.application.name=hhplus-consertReservation
 
-# MySQL ?????? ?? ??
+# MySQL ?????? ??
 spring.datasource.url=jdbc:mysql://localhost:3306/concert_reservation_db
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
 spring.datasource.password=1q2w3e4r!
 
-# JPA ?? - ???? ?? ???? ??? ??
+# JPA ?? - ?????? ??? ?? ??
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# SpringDoc Swagger ?? (??? ??)
+# SpringDoc Swagger ?? (API ?? ??)
 springdoc.api-docs.path=/v3/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 
-# ?? ?? ??
+# ?? ??
 logging.level.root=info
 logging.level.com.concert_reservation=info
 
-# ???? ? ??? ?? ?? ??
+# JWT ?? ??
 token.secret=your-secret-key  
-# ?? ?? ?? (1?, ??? ??)
-token.expiration=86400000      
+# ?? ?? ?? (1?)
+token.expiration=86400000     
+
+# Kafka ??
+spring.kafka.bootstrap-servers=localhost:9092
+
+# Kafka Producer ??
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Kafka Consumer ??
+spring.kafka.consumer.group-id=test-group
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# ??? Kafka ?? (?: ??? ?? ???? ??? ??)
+spring.kafka.topic.concert-events=concert-events

--- a/src/test/java/com/consertreservation/application/scheduler/OutboxSchedulerTest.java
+++ b/src/test/java/com/consertreservation/application/scheduler/OutboxSchedulerTest.java
@@ -1,0 +1,77 @@
+package com.consertreservation.application.scheduler;
+
+import com.consertreservation.domain.model.OutboxEvent;
+import com.consertreservation.domain.repository.OutboxRepository;
+import com.consertreservation.kafka.KafkaOutboxPublisher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class OutboxSchedulerTest {
+
+    private OutboxRepository outboxRepository;
+    private KafkaOutboxPublisher kafkaOutboxPublisher;
+    private OutboxScheduler outboxScheduler;
+
+    @BeforeEach
+    void setUp() {
+        outboxRepository = mock(OutboxRepository.class);
+        kafkaOutboxPublisher = mock(KafkaOutboxPublisher.class);
+        outboxScheduler = new OutboxScheduler(outboxRepository, kafkaOutboxPublisher);
+    }
+
+    @Test
+    @DisplayName("FAILED 상태의 Outbox 이벤트를 재처리하여 Kafka로 발행 성공 시 상태가 PROCESSED로 변경된다.")
+    void testRetryFailedEvents_Success() {
+        // Given
+        OutboxEvent failedEvent = new OutboxEvent();
+        failedEvent.setId(1L);
+        failedEvent.setAggregateType("Reservation");
+        failedEvent.setAggregateId("A1");
+        failedEvent.setEventType("SEAT_RESERVED");
+        failedEvent.setPayload("{\"userId\": \"user1\", \"concertId\": \"1\", \"seatNumber\": \"A1\"}");
+        failedEvent.setStatus("FAILED");
+
+        when(outboxRepository.findByStatus("FAILED")).thenReturn(List.of(failedEvent));
+
+        // When
+        outboxScheduler.retryFailedEvents();
+
+        // Then
+        verify(kafkaOutboxPublisher).publish(failedEvent);
+        verify(outboxRepository).save(failedEvent);
+        assertThat(failedEvent.getStatus()).isEqualTo("PROCESSED");
+    }
+
+    @Test
+    @DisplayName("Kafka 발행 실패 시 FAILED 상태로 유지된다.")
+    void testRetryFailedEvents_Failure() {
+        // Given
+        OutboxEvent failedEvent = new OutboxEvent();
+        failedEvent.setId(1L);
+        failedEvent.setAggregateType("Reservation");
+        failedEvent.setAggregateId("A1");
+        failedEvent.setEventType("SEAT_RESERVED");
+        failedEvent.setPayload("{\"userId\": \"user1\", \"concertId\": \"1\", \"seatNumber\": \"A1\"}");
+        failedEvent.setStatus("FAILED");
+
+        when(outboxRepository.findByStatus("FAILED")).thenReturn(List.of(failedEvent));
+        doThrow(new RuntimeException("Kafka 발행 실패")).when(kafkaOutboxPublisher).publish(failedEvent);
+
+        // When
+        outboxScheduler.retryFailedEvents();
+
+        // Then
+        verify(kafkaOutboxPublisher).publish(failedEvent);
+        verify(outboxRepository).save(failedEvent);
+        assertThat(failedEvent.getStatus()).isEqualTo("FAILED");
+    }
+
+}

--- a/src/test/java/com/consertreservation/kafka/EmbeddedKafkaConfig.java
+++ b/src/test/java/com/consertreservation/kafka/EmbeddedKafkaConfig.java
@@ -1,0 +1,17 @@
+package com.consertreservation.kafka;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+
+//테스트 환경에서 Kafka 브로커를 임베디드로 실행할 수 있도록 설정
+@Configuration
+public class EmbeddedKafkaConfig {
+
+    @Bean
+    public EmbeddedKafkaBroker embeddedKafkaBroker() {
+        return new EmbeddedKafkaBroker(1, true, 1, "test-topic")
+                .brokerProperty("listeners", "PLAINTEXT://localhost:9092")
+                .brokerProperty("port", "9092");
+    }
+}

--- a/src/test/java/com/consertreservation/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/com/consertreservation/kafka/KafkaIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.consertreservation.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@EmbeddedKafka(partitions = 1, topics = {"test-topic"})
+class KafkaIntegrationTest {
+
+    @Autowired
+    private EmbeddedKafkaBroker embeddedKafkaBroker;
+
+    @Test
+    @DisplayName("카프카 정상 작동 테스트_Producer와 Consumer 간 메시지 일치 확인")
+    void testKafkaMessageSendAndReceive() {
+        // 1. Producer 설정
+        Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafkaBroker);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        Producer<String, String> producer = new org.apache.kafka.clients.producer.KafkaProducer<>(producerProps);
+
+        // 2. 메시지 보내기
+        String testMessage = "Hello, Kafka!";
+        producer.send(new ProducerRecord<>("test-topic", "key", testMessage));
+        producer.flush();
+
+        // 3. Consumer 설정
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(
+                "test-group", "true", embeddedKafkaBroker);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        Consumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singletonList("test-topic"));
+
+        // 4. 메시지 수신 및 검증
+        var records = KafkaTestUtils.getRecords(consumer);
+        assertThat(records.count()).isGreaterThan(0);
+        assertThat(records.iterator().next().value()).isEqualTo(testMessage);
+
+        consumer.close();
+        producer.close();
+    }
+}
+
+

--- a/src/test/java/com/consertreservation/kafka/KafkaIntegrationTest.java
+++ b/src/test/java/com/consertreservation/kafka/KafkaIntegrationTest.java
@@ -60,6 +60,76 @@ class KafkaIntegrationTest {
         consumer.close();
         producer.close();
     }
+
+    @Test
+    @DisplayName("Kafka Producer 및 Consumer 테스트 - 예약 성공 메시지 발행 및 수신")
+    void testReservationEventProducedAndConsumed() {
+        // 1. Producer 설정
+        Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafkaBroker);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        Producer<String, String> producer = new org.apache.kafka.clients.producer.KafkaProducer<>(producerProps);
+
+        // 2. Kafka 메시지 발행
+        String topic = "reservation-events";
+        String testMessage = "예약 성공: test-user, 좌석: A1";
+        producer.send(new ProducerRecord<>(topic, "key", testMessage));
+        producer.flush();
+
+        // 3. Consumer 설정
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(
+                "test-group", "true", embeddedKafkaBroker);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        Consumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singletonList(topic));
+
+        // 4. 메시지 수신 및 검증
+        var records = KafkaTestUtils.getRecords(consumer);
+        assertThat(records.count()).isGreaterThan(0);
+        assertThat(records.iterator().next().value()).isEqualTo(testMessage);
+
+        // 5. 리소스 정리
+        consumer.close();
+        producer.close();
+    }
+
+    @Test
+    @DisplayName("Kafka Producer 및 Consumer 테스트 - 대기열 추가 메시지 발행 및 수신")
+    void testWaitlistEventProducedAndConsumed() {
+        // 1. Producer 설정
+        Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafkaBroker);
+        producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+        Producer<String, String> producer = new org.apache.kafka.clients.producer.KafkaProducer<>(producerProps);
+
+        // 2. Kafka 메시지 발행
+        String topic = "waitlist-events";
+        String testMessage = "대기열 추가: test-user, 좌석: A2";
+        producer.send(new ProducerRecord<>(topic, "key", testMessage));
+        producer.flush();
+
+        // 3. Consumer 설정
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(
+                "test-group", "true", embeddedKafkaBroker);
+        consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        Consumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singletonList(topic));
+
+        // 4. 메시지 수신 및 검증
+        var records = KafkaTestUtils.getRecords(consumer);
+        assertThat(records.count()).isGreaterThan(0);
+        assertThat(records.iterator().next().value()).isEqualTo(testMessage);
+
+        // 5. 리소스 정리
+        consumer.close();
+        producer.close();
+    }
 }
 
 

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,3 +4,19 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+
+# Kafka ??
+spring.kafka.bootstrap-servers=localhost:9092
+
+# Kafka Producer ??
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+
+# Kafka Consumer ??
+spring.kafka.consumer.group-id=test-group
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
+# ??? Kafka ?? (?: ??? ?? ???? ??? ??)
+spring.kafka.topic.concert-events=concert-events


### PR DESCRIPTION
 -- STEP 18
- 기존 애플리케이션 이벤트를 카프카 메세지 발행으로 변경
- Outbox Pattern 도입으로 이벤트 발행 안정성 강화(`outbox_events` 테이블 추가)
- Scheduler를 통해 PENDING 상태 이벤트를 Kafka로 발행
- Kafka 발행 실패 시 재처리 로직 구현
- 관련 테스트 추가 및 검증